### PR TITLE
feat: 배틀룸 유저입장 확인 소켓 설정

### DIFF
--- a/src/constants/eventName.js
+++ b/src/constants/eventName.js
@@ -5,4 +5,7 @@ module.exports = {
   UPDATE_USER: "update-user",
   SEND_BATTLES: "send-battles",
   RECEIVE_BATTLES: "receive-battles",
+  CHECK_USERS: "check_users",
+  USER_LEAVE: "user_leave",
+  BEAT: "BEAT",
 };

--- a/src/constants/eventName.js
+++ b/src/constants/eventName.js
@@ -7,5 +7,6 @@ module.exports = {
   RECEIVE_BATTLES: "receive-battles",
   CHECK_USERS: "check_users",
   USER_LEAVE: "user_leave",
+  USER_JOINED: "user_joined",
   BEAT: "BEAT",
 };

--- a/src/utils/socket.js
+++ b/src/utils/socket.js
@@ -12,6 +12,7 @@ const {
   RECEIVE_BATTLES,
   CHECK_USERS,
   USER_LEAVE,
+  USER_JOINED,
   BEAT,
 } = require("../constants/eventName");
 
@@ -88,7 +89,7 @@ battles.on("connection", (socket) => {
     socket.join(roomId);
     io.of("/").emit(CHECK_USERS, battleCurrentUsers);
 
-    socket.in(roomId).emit("user_joined", user);
+    socket.in(roomId).emit(USER_JOINED, user);
     socket.emit(UPDATE_USER, Object.values(usersInRoom));
 
     socket.on(SEND_BATTLES, ({ key, score }) => {


### PR DESCRIPTION
## 📝 Description
로비에서 각방에 유저의 입장한 명수를 확인하기 위해 소켓을 설정해주었습니다.
유저가 입장했을때  각방의 정보를  `usersInRoom` 변수에 `{배틀룸id: {유저의uid: 유저정보}}` 형태로 만들어주고 이미 만들어 진 방이 있다면 `usersInRoom` 객체에 `{유저의uid: 유저정보}`를 추가하여 줍니다.

### socket.io
>- `CHECK_USERS`:  `CHECK_USERS` 이벤트가 발생되면 `socket.js`위치에 있는 `battleCurrentUsers`변수 (`battleCurrentUsers` 변수는 객체이며 방에 입장한 유저 `방id:{유저uid :  유저정보}` 형태입니다.) 를 전달합니다.
>- `USER_LEAVE` 해당 페이지에서 유저가 `disconnect`된다면 유저의 uid로 battleCurrentUsers변수에서 유저의 정보를 삭제 합니다.
>-  `USER_JOINED` 이벤트는 `connection`하였을때 `user`의 이름을 클라이언트로 보내줍니다.

## ❗ Related Issues
N/A

## 🛠️ Changes
아래 상수를 추가 해주었습니다.
  `CHECK_USERS: "check_users"`
  `USER_LEAVE: "user_leave"`
  `USER_JOINED: "user_joined"`
  `BEAT: "BEAT"`
  
 ` socket.js`의 `currentUsers` 변수를 `lobbyCurrentUsers`로 구체화 해주었습니다.
