### PR TITLE
feat: 입장한방에서 선택한 음악에 맞는 노트 연결

### DIFF
--- a/src/models/Note.js
+++ b/src/models/Note.js
@@ -2,26 +2,29 @@ const mongoose = require("mongoose");
 
 const NoteSchema = new mongoose.Schema({
   title: {
-    type: mongoose.Schema.Types.ObjectId,
-    ref: "Song",
-    required: true,
-  },
-  time: {
-    type: Number,
-    required: true,
-    default: 0,
-    min: 0,
-  },
-  key: {
     type: String,
     required: true,
   },
-  positionY: {
-    type: Number,
-    required: true,
-    default: 0,
-    min: 0,
-  },
+  note: [
+    {
+      time: {
+        type: Number,
+        required: true,
+        default: 0,
+        min: 0,
+      },
+      key: {
+        type: String,
+        required: true,
+      },
+      positionY: {
+        type: Number,
+        required: true,
+        default: 0,
+        min: 0,
+      },
+    },
+  ],
 });
 
 module.exports = mongoose.model("Note", NoteSchema);

--- a/src/models/Song.js
+++ b/src/models/Song.js
@@ -1,12 +1,6 @@
 const mongoose = require("mongoose");
 
 const SongSchema = new mongoose.Schema({
-  notes: [
-    {
-      type: mongoose.Schema.Types.ObjectId,
-      ref: "Note",
-    },
-  ],
   title: {
     type: String,
     required: true,

--- a/src/routes/controllers/room.Controller.js
+++ b/src/routes/controllers/room.Controller.js
@@ -1,6 +1,7 @@
 const mongoose = require("mongoose");
 const Song = require("../../models/Song");
 const BattleRoom = require("../../models/BattleRoom");
+const Note = require("../../models/Note");
 const AWS = require("aws-sdk");
 const s3 = new AWS.S3();
 const BUCKET = process.env.AWS_BUCKET;
@@ -115,7 +116,12 @@ exports.getBattleData = async (req, res, next) => {
       return res.status(404).send({ message: "Song not found" });
     }
 
-    res.send({ song, room });
+    const note = await Note.findOne({ title: song.title });
+    if (!note) {
+      return res.status(404).send({ message: "Note not found" });
+    }
+
+    res.send({ song, room, note });
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
## 📝 Description
방을 생성할때 선택한곡에 맞는 노트 데이터를 클라이언트에서 필요로 하기때문에 `db` `NoteSchema` 에서 `SongSchema`의 `title`값으로 해당하는 노트를 `find`하여 클아이언트로 데이터를 전송해었습니다.

- `song.title`로 `Note``title`이 일치 한다면 해당 노트를 정보를 클라이언트로 보내주었습니다.
- `song.title`이 `Note``title`이 일치 하지 않는다면 에러처리를 해주었습니다.

## ❗ Related Issues
N/A

## 🛠️ Changes
**Schema 수정**
- 팀원들과 결정을 바탕으로 Schema 수정를 수정해주었습니다.
- `NoteSchema` 에서 `SongSchema`을 참조하는 것이 계획이였지만 토의결과 `Note`가 정적인 데이터 이므로 직접 `title`을 입력해주고 참조를 하여 불필요한 데이터 정보가 많아서 참조하는것을 취소하였습니다.
- `SongSchema` 에서 `NoteSchema`을 참조하는 것이 계획이였지만 토의결과 `Note`을 참조하여 모든곡의 노트를 참조하는 하여 불필요한 데이터를 참조하는 것보다 `Song`의 `title`로  `Note`의 `title`과 일치한다면 해당 노트의 정보를 클라이언트로 보내주는 것으로 결정 하였습니다.

