### PR TITLE
feat: 배틀룸 결과 창 정보를 위한 소켓 셋팅

### DIFF
--- a/src/constants/eventName.js
+++ b/src/constants/eventName.js
@@ -24,4 +24,6 @@ module.exports = {
   RECEIVE_OPPONENT_KEY_PRESS: "receive-opponent-key-press",
   RECEIVE_DELETE: "receive-delete",
   USER_LEFT: "user-left",
+  SEND_RESULTS: "send-results",
+  RECEIVE_RESULTS: "receive-results",
 };

--- a/src/utils/socket.js
+++ b/src/utils/socket.js
@@ -29,6 +29,8 @@ const {
   FROM_BATTLEROOM,
   SEND_USER,
   USER_LEFT,
+  SEND_RESULTS,
+  RECEIVE_RESULTS,
 } = require("../constants/eventName");
 
 const server = http.createServer(app);
@@ -188,11 +190,9 @@ results.on("connection", (socket) => {
 
   const user = { photoURL, displayName, uid };
 
-  socket.on("send-results", (comboResults, totalScore) => {
-    socket.to(resultId).emit("receive-results", comboResults, totalScore, user);
+  socket.on(SEND_RESULTS, (comboResults, totalScore) => {
+    socket.to(resultId).emit(RECEIVE_RESULTS, comboResults, totalScore, user);
   });
 
-  socket.on("disconnect", () => {
-    // socket.emit("user-out");
-  });
+  socket.on("disconnect", () => {});
 });

--- a/src/utils/socket.js
+++ b/src/utils/socket.js
@@ -48,6 +48,7 @@ const io = socketIO(server, {
 });
 
 const battles = io.of("/battles/");
+const results = io.of("/results/");
 const battleRooms = {};
 const usersInRoom = {};
 let lobbyUsers = {};
@@ -178,5 +179,20 @@ battles.on("connection", (socket) => {
 
     socket.to(roomId).emit(USER_LEFT, uid);
     socket.to(roomId).emit(RECEIVE_BATTLES, null);
+  });
+});
+
+results.on("connection", (socket) => {
+  const { photoURL, displayName, uid, resultId } = socket.handshake.query;
+  socket.join(resultId);
+
+  const user = { photoURL, displayName, uid };
+
+  socket.on("send-results", (comboResults, totalScore) => {
+    socket.to(resultId).emit("receive-results", comboResults, totalScore, user);
+  });
+
+  socket.on("disconnect", () => {
+    // socket.emit("user-out");
   });
 });


### PR DESCRIPTION
## 📝 Description
- 배틀룸의 결과 창을 노래가 끝나자마자 바로 보여줄 수 있게 구현하기 위해 `socket`을 통해 구현하였습니다.

## ❗ Related Issues
N/A

## 🛠️ Changes
- 상수 처리를 해주었습니다.
- `results` , `namespace`를 추가해주었습니다.


## 📸 Screenshot
