### PR TITLE
test: GET api/rooms 구현

### DIFF
--- a/tests/api/rooms.test.js
+++ b/tests/api/rooms.test.js
@@ -1,0 +1,111 @@
+const request = require("supertest");
+const app = require("../../src/app");
+const mongoMemoryServer = require("../../mongoMemoryServer");
+const BattleRoom = require("../../src/models/BattleRoom");
+const Song = require("../../src/models/Song");
+
+describe("GET /api/rooms", () => {
+  beforeAll(async () => {
+    await mongoMemoryServer.connect();
+  });
+
+  afterAll(async () => {
+    await mongoMemoryServer.closeDatabase();
+  });
+
+  afterEach(async () => {
+    await BattleRoom.deleteMany({});
+  });
+
+  it("returns all rooms", async () => {
+    const songOne = new Song({
+      notes: [],
+      title: "Fake Love",
+      audioURL: "https://bucketname.s3.location.amazonaws/music/fakelove",
+      imageURL: "https://bucketname.s3.location.amazonaws/image/fakelove",
+      artist: "BTS",
+    });
+
+    await songOne.save();
+
+    const songTwo = new Song({
+      notes: [],
+      title: "왕벌의 비행",
+      audioURL: "https://bucketname.s3.location.amazonaws/music/memory",
+      imageURL: "https://bucketname.s3.location.amazonaws/image/memory",
+      artist: "Rimsky-Korsakov",
+    });
+
+    await songTwo.save();
+
+    const songThree = new Song({
+      notes: [],
+      title: "Your Song",
+      audioURL: "https://bucketname.s3.location.amazonaws/music/yoursong",
+      imageURL: "https://bucketname.s3.location.amazonaws/image/yoursong",
+      artist: "Elton John",
+    });
+
+    await songThree.save();
+
+    const roomOne = new BattleRoom({
+      song: songOne._id,
+      createdBy: "최연석",
+      uid: "m5zw3tb2fqpfeqjmg97twmyhlgq2",
+    });
+
+    const roomTwo = new BattleRoom({
+      song: songTwo._id,
+      createdBy: "복달",
+      uid: "G30XEWAkD9eJTSDdluAoISMcPVC2",
+    });
+
+    const roomThree = new BattleRoom({
+      song: songThree._id,
+      createdBy: "송미르",
+      uid: "M5ZW3tB2FQPfeQJMG97TWmyHLGQ2",
+    });
+
+    await BattleRoom.create(roomOne);
+    await BattleRoom.create(roomTwo);
+    await BattleRoom.create(roomThree);
+
+    const response = await request(app).get("/api/rooms");
+    expect(response.status).toEqual(200);
+    expect(response.body.rooms).toHaveLength(3);
+
+    const expectedRooms = [
+      { createdBy: roomOne.createdBy, uid: roomOne.uid },
+      { createdBy: roomTwo.createdBy, uid: roomTwo.uid },
+      { createdBy: roomThree.createdBy, uid: roomThree.uid },
+    ];
+
+    response.body.rooms.forEach((room, index) => {
+      expect(room.createdBy).toEqual(expectedRooms[index].createdBy);
+      expect(room.song).toBeDefined();
+      expect(room.song).toBeInstanceOf(Object);
+      expect(room.uid).toEqual(expectedRooms[index].uid);
+    });
+  });
+
+  it("returns an error if BattleRoom model or song field is missing", async () => {
+    const songPath = BattleRoom.schema.paths.song;
+    BattleRoom.schema.remove("song");
+
+    const roomOne = new BattleRoom({
+      createdBy: "최연석",
+      uid: "m5zw3tb2fqpfeqjmg97twmyhlgq2",
+    });
+
+    await BattleRoom.create(roomOne);
+
+    const response = await request(app).get("/api/rooms");
+
+    expect(response.status).toEqual(500);
+    expect(response.body.message).toEqual(
+      "BattleRoom model or song field is missing",
+    );
+
+    BattleRoom.schema.add({ song: songPath });
+  });
+});

--- a/tests/api/users.test.js
+++ b/tests/api/users.test.js
@@ -1,6 +1,5 @@
 const request = require("supertest");
 const app = require("../../src/app");
-const jwt = require("jsonwebtoken");
 const User = require("../../src/models/User");
 const mongoMemoryServer = require("../../mongoMemoryServer");
 
@@ -13,52 +12,62 @@ describe("POST /api/users/login", () => {
     await mongoMemoryServer.closeDatabase();
   });
 
+  beforeEach(async () => {
+    const mockUser = {
+      accessToken: "access-token",
+      uid: "641df1ac5bfa32a524169090",
+      name: "Charlie Black",
+      photoURL: "https://www.pbb/cb-color.jpg",
+    };
+
+    await User.create(mockUser);
+  });
+
   afterEach(async () => {
     await User.deleteMany({});
   });
 
-  const mockUser = {
-    uid: "641df1ac5bfa32a524169098",
-    name: "Charlie Brown",
-    photoURL: "https://www.peanuts.com/sites/default/files/cb-color.jpg",
-  };
-
-  jest.mock("../../src/routes/middlewares/verifyToken", () => {
-    return jest.fn((req, res, next) => {
-      req.user = { accessToken: "mocked-token" };
-      next();
-    });
-  });
-
   it("returns a 201 response with all users and a token if the user does not exist", async () => {
-    jest.spyOn(jwt, "sign").mockReturnValue("mocked-token");
-    const user = new User(mockUser);
-    await user.save();
+    const mockUser = {
+      accessToken: "access-token",
+      uid: "641df1ac5bfa32a524169098",
+      name: "Charlie Brown",
+      photoURL: "https://www.peanuts.com/sites/default/files/cb-color.jpg",
+    };
+
+    const usersBefore = await User.find({});
 
     const response = await request(app)
       .post("/api/users/login")
       .send({
-        accessToken: "mocked-access-token",
+        accessToken: mockUser.accessToken,
         uid: mockUser.uid,
         displayName: mockUser.name,
         photoURL: mockUser.photoURL,
       })
-      .set("Authorization", "Bearer mocked-token")
       .set("Content-Type", "application/json")
       .set("Accept", "application/json");
 
     expect(response.status).toEqual(201);
     expect(response.body.users).toBeDefined();
-    expect(response.body.token).toEqual("mocked-token");
+    expect(response.body.token).toBeDefined();
 
-    const users = await User.find({});
-    expect(users.length).toEqual(1);
-    expect(users[0].uid).toEqual(mockUser.uid);
-    expect(users[0].name).toEqual(mockUser.name);
-    expect(users[0].photoURL).toEqual(mockUser.photoURL);
+    const usersAfter = await User.find({});
+    const addedUser = await User.findOne({
+      uid: mockUser.uid,
+    });
+
+    expect(usersAfter.length).toEqual(usersBefore.length + 1);
+    expect(addedUser).toBeDefined();
   });
 
   it("return a 401 response with an error message if any of user data is missing", async () => {
+    const mockUser = {
+      uid: "641df1ac5bfa32a524169098",
+      name: "Charlie Brown",
+      photoURL: "https://www.peanuts.com/sites/default/files/cb-color.jpg",
+    };
+
     const response = await request(app).post("/api/users/login").send({
       uid: mockUser.uid,
       displayName: mockUser.name,


### PR DESCRIPTION
## 📝 Description

로비에서 존재하는 모든 방을 가져와주는데 `BattleRoom` 모델이나 `song` 속성이 없는 경우에는 에러를 반환합니다. 

## ❗ Related Issues

`api/rooms/new`와 `api/rooms/:roomId`에서 `verifyToken` 미들웨어를 사용하는데 추후에 테스트를 위한 mocked verifyToken middleware를 알맞게 작성하는지 확인이 필요합니다.

## 🛠️ Changes

- 로비에서 모든 방을 잘 반환하는지 200응답과 `BattleRoom` 속성데이터(`createdBy`, `uid`, `song`)을 확인합니다. `song`이 `null`이 아니고 `Objectid`인지 확인합니다. 
- `Song` 스키마 속성을 지우고 저장하였을 때 500응답과 에러를 반환합니다. 
-  테스트가 끝난 후에는 테스트 과정에서 생성된 방을 모두 인메모리 데이터베이스에서 삭제해줍니다.

## 📸 Screenshot
