### PR TITLE
test: users, rooms, proxy 엔드포인트와 verifyToken 테스트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .env
 node_modules
 .eslintignore
+
+/coverage

--- a/app.test.js
+++ b/app.test.js
@@ -1,0 +1,18 @@
+const express = require("express");
+const { mockedVerifyToken } = require("./tests/mocks/auth.mock");
+const roomController = require("./src/routes/controllers/room.Controller");
+
+const app = express();
+
+app.use(express.json());
+
+app.get("/api/rooms/new", mockedVerifyToken, roomController.getSongs);
+app.post("/api/rooms/new", mockedVerifyToken, roomController.makeRoom);
+app.get("/api/rooms/:roomId", mockedVerifyToken, roomController.getBattleData);
+app.delete(
+  "/api/rooms/:roomId",
+  mockedVerifyToken,
+  roomController.deleteBattleRoom,
+);
+
+module.exports = app;

--- a/mongoMemoryServer.js
+++ b/mongoMemoryServer.js
@@ -3,7 +3,7 @@ const mongoose = require("mongoose");
 const mongoServer = new MongoMemoryServer();
 
 async function connect() {
-  await mongoServer.start(); // Add this line to start the server
+  await mongoServer.start();
   const uri = await mongoServer.getUri();
 
   const mongooseOpts = {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint:fix": "eslint --fix .",
     "prepare": "husky install",
     "pre-commit": "lint-staged",
-    "test": "NODE_ENV=test jest"
+    "test": "NODE_ENV=test jest --coverage --watchAll"
   },
   "devDependencies": {
     "eslint": "^8.36.0",

--- a/src/routes/controllers/user.Controller.js
+++ b/src/routes/controllers/user.Controller.js
@@ -87,11 +87,11 @@ exports.localLogin = async (req, res, next) => {
   }
 };
 
-exports.deleteUser = async (req, res, next) => {
+exports.deleteLocalUser = async (req, res, next) => {
   const { email } = req.body;
 
   try {
-    await User.deleteOne({ email });
+    await User.deleteOne({ uid: email });
 
     res.status(204).send({ result: "delete" });
   } catch (err) {

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -8,6 +8,6 @@ router.post("/logout", userController.logoutUser);
 router.post("/local/login", userController.localLogin);
 router.post("/local/register", userController.localRegister);
 
-router.delete("/delete", userController.deleteUser);
+router.delete("/delete", userController.deleteLocalUser);
 
 module.exports = router;

--- a/src/utils/mongoose.js
+++ b/src/utils/mongoose.js
@@ -1,7 +1,5 @@
 const mongoose = require("mongoose");
 
-/**
- **/
 function connectMongoDB() {
   mongoose.set("strictQuery", false);
 

--- a/tests/api/rooms.test.js
+++ b/tests/api/rooms.test.js
@@ -1,12 +1,15 @@
 const request = require("supertest");
 const app = require("../../src/app");
+const appTest = require("../../app.test");
 const mongoMemoryServer = require("../../mongoMemoryServer");
 const BattleRoom = require("../../src/models/BattleRoom");
 const Song = require("../../src/models/Song");
+const Note = require("../../src/models/Note");
 
-describe("Room Test /api/rooms", () => {
+describe("GET /api/rooms", () => {
   beforeAll(async () => {
     await mongoMemoryServer.connect();
+    await BattleRoom.deleteMany({});
   });
 
   afterAll(async () => {
@@ -15,7 +18,6 @@ describe("Room Test /api/rooms", () => {
 
   beforeEach(async () => {
     const songOne = {
-      notes: [],
       title: "Fake Love",
       audioURL: "https://bucketname.s3.location.amazonaws/music/fakelove",
       imageURL: "https://bucketname.s3.location.amazonaws/image/fakelove",
@@ -23,7 +25,6 @@ describe("Room Test /api/rooms", () => {
     };
 
     const songTwo = {
-      notes: [],
       title: "왕벌의 비행",
       audioURL: "https://bucketname.s3.location.amazonaws/music/memory",
       imageURL: "https://bucketname.s3.location.amazonaws/image/memory",
@@ -31,7 +32,6 @@ describe("Room Test /api/rooms", () => {
     };
 
     const songThree = {
-      notes: [],
       title: "Your Song",
       audioURL: "https://bucketname.s3.location.amazonaws/music/yoursong",
       imageURL: "https://bucketname.s3.location.amazonaws/image/yoursong",
@@ -54,23 +54,23 @@ describe("Room Test /api/rooms", () => {
       title: "Your Song",
     });
 
-    const roomOne = new BattleRoom({
+    const roomOne = {
       song: addedSongOne._id,
       createdBy: "최연석",
       uid: "m5zw3tb2fqpfeqjmg97twmyhlgq2",
-    });
+    };
 
-    const roomTwo = new BattleRoom({
+    const roomTwo = {
       song: addedSongTwo._id,
       createdBy: "복달",
       uid: "G30XEWAkD9eJTSDdluAoISMcPVC2",
-    });
+    };
 
-    const roomThree = new BattleRoom({
+    const roomThree = {
       song: addedSongThree._id,
       createdBy: "송미르",
       uid: "M5ZW3tB2FQPfeQJMG97TWmyHLGQ2",
-    });
+    };
 
     await BattleRoom.create(roomOne);
     await BattleRoom.create(roomTwo);
@@ -82,7 +82,7 @@ describe("Room Test /api/rooms", () => {
     await BattleRoom.deleteMany({});
   });
 
-  it("GET /api/rooms", async () => {
+  it("returns all the existing battle rooms", async () => {
     const response = await request(app).get("/api/rooms");
     expect(response.status).toEqual(200);
     expect(response.body.rooms).toHaveLength(3);
@@ -98,18 +98,242 @@ describe("Room Test /api/rooms", () => {
   });
 
   it("returns an error if BattleRoom model or song field is missing", async () => {
-    await BattleRoom.deleteMany({});
-    const sampleRoom = new BattleRoom({
+    const sampleRoom = {
       song: "invalidId",
-      createdBy: "최연소",
+      createdBy: "anonymous",
       uid: "m5zw3tb2fqpfeqjmg97twmyhlgq5",
-    });
+    };
 
     try {
       await BattleRoom.create(sampleRoom);
-    } catch (e) {
-      const errorMessage = e;
+    } catch (err) {
+      const errorMessage = err;
       expect(errorMessage).toBeDefined();
     }
+  });
+});
+
+describe("GET /api/rooms/new", () => {
+  beforeAll(async () => {
+    await mongoMemoryServer.connect();
+  });
+
+  afterAll(async () => {
+    await Song.deleteMany();
+    await mongoMemoryServer.closeDatabase();
+  });
+
+  it("returns a list of songs with their corresponding audio and image URLs", async () => {
+    const response = await request(appTest).get("/api/rooms/new");
+
+    expect(response.status).toBe(200);
+    expect(response.body.songs.length).toEqual(3);
+    response.body.songs.forEach((song) => {
+      expect(song).toHaveProperty("_id");
+      expect(song).toHaveProperty("title");
+      expect(typeof song.title).toEqual("string");
+      expect(song.title.length).toBeGreaterThan(1);
+      expect(song).toHaveProperty("audioURL");
+      expect(song).toHaveProperty("imageURL");
+      expect(song).toHaveProperty("artist");
+      expect(typeof song.artist).toEqual("string");
+      expect(song.artist.length).toBeGreaterThan(1);
+    });
+  });
+});
+
+describe("POST /api/rooms/new", () => {
+  let addedSong;
+
+  beforeAll(async () => {
+    await mongoMemoryServer.connect();
+
+    const testSong = {
+      title: "Billie Jean",
+      audioURL: "https://bucketname.s3.location.amazonaws/music/billiejean",
+      imageURL: "https://bucketname.s3.location.amazonaws/image/billiejean",
+      artist: "Micheal Jackson",
+    };
+
+    await Song.create(testSong);
+
+    addedSong = await Song.findOne({
+      title: "Billie Jean",
+    });
+  });
+
+  afterAll(async () => {
+    await mongoMemoryServer.closeDatabase();
+  });
+
+  afterEach(async () => {
+    await BattleRoom.deleteMany({});
+  });
+
+  it("creates a new battle room with valid request data and returns 201 status code", async () => {
+    const roomListBefore = await BattleRoom.find({});
+
+    const newRoom = {
+      song: addedSong._id,
+      createdBy: "artist",
+      uid: "m5zw3tb2fqpfeqjmg97twmyhlgq3",
+    };
+
+    const response = await request(appTest)
+      .post("/api/rooms/new")
+      .send(newRoom);
+
+    const roomListAfter = await BattleRoom.find({});
+
+    const addedRoom = await BattleRoom.find({
+      uid: newRoom.uid,
+    });
+
+    expect(response.status).toEqual(201);
+    expect(addedRoom).toBeDefined();
+    expect(roomListAfter.length).toEqual(roomListBefore.length + 1);
+  });
+
+  it("returns a 400 status when the request body is missing a field", async () => {
+    const newRoom = {
+      song: addedSong._id,
+      createdBy: "artist",
+    };
+
+    const response = await request(appTest)
+      .post("/api/rooms/new")
+      .send(newRoom);
+
+    expect(response.status).toEqual(400);
+    expect(response.body).toEqual({ message: "Invalid requested body" });
+  });
+});
+
+describe("GET /api/rooms/:roomId", () => {
+  let idFound;
+
+  beforeAll(async () => {
+    await mongoMemoryServer.connect();
+    const sampleSong = {
+      title: "Billie Jean",
+      audioURL: "https://bucketname.s3.location.amazonaws/music/billiejean",
+      imageURL: "https://bucketname.s3.location.amazonaws/image/billiejean",
+      artist: "Micheal Jackson",
+    };
+
+    await Song.create(sampleSong);
+
+    const addedSong = await Song.findOne({
+      title: sampleSong.title,
+    });
+
+    const newNote = {
+      title: sampleSong.title,
+      note: [
+        {
+          time: 0.2,
+          key: "s",
+          positionY: 0,
+        },
+        {
+          time: 0.3,
+          key: "d",
+          positionY: 0,
+        },
+      ],
+    };
+
+    await Note.create(newNote);
+
+    const newRoom = {
+      song: addedSong._id,
+      createdBy: "artist",
+      uid: "m5zw3tb2fqpfeqjmg97twmyhlgq3",
+    };
+
+    await BattleRoom.create(newRoom);
+
+    const roomIdFound = await BattleRoom.findOne({
+      uid: "m5zw3tb2fqpfeqjmg97twmyhlgq3",
+    });
+
+    idFound = roomIdFound._id.toString();
+  });
+
+  afterAll(async () => {
+    await Song.deleteMany({});
+    await BattleRoom.deleteMany({});
+    await Note.deleteMany({});
+    await mongoMemoryServer.closeDatabase();
+  });
+
+  it("returns a 400 error when given an invalid roomId", async () => {
+    const response = await request(appTest).get("/api/rooms/invalidId");
+
+    expect(response.status).toEqual(400);
+    expect(response.body.message).toEqual("Invalid URL");
+  });
+
+  it("returns a room, song, and note when given a valid roomId", async () => {
+    const response = await request(appTest).get(`/api/rooms/${idFound}`);
+
+    expect(response.status).toEqual(200);
+    expect(response.body.song).toBeDefined();
+    expect(response.body.room).toBeDefined();
+    expect(response.body.note).toBeDefined();
+  });
+});
+
+describe("DELETE /api/rooms/:roomId", () => {
+  beforeAll(async () => {
+    await mongoMemoryServer.connect();
+
+    const testSong = {
+      title: "Hey Ya!",
+      audioURL: "https://bucketname.s3.location.amazonaws/music/heyya",
+      imageURL: "https://bucketname.s3.location.amazonaws/image/heyya",
+      artist: "OutKast",
+    };
+
+    await Song.create(testSong);
+
+    const addedSongOne = await Song.findOne({
+      title: "Hey Ya!",
+    });
+
+    const testRoom = {
+      song: addedSongOne._id,
+      createdBy: "도레미",
+      uid: "m5zw3tb2fqpfeqjmg97twmyhlgq7",
+    };
+
+    await BattleRoom.create(testRoom);
+  });
+
+  afterAll(async () => {
+    await mongoMemoryServer.closeDatabase();
+  });
+
+  it("deletes a battle room and return 204 status code", async () => {
+    const roomIdFound = await BattleRoom.findOne({
+      uid: "m5zw3tb2fqpfeqjmg97twmyhlgq7",
+    });
+
+    const idFound = roomIdFound._id.toString();
+
+    const response = await request(appTest).delete(`/api/rooms/${idFound}`);
+    const deletedRoom = await BattleRoom.findOne({
+      uid: "m5zw3tb2fqpfeqjmg97twmyhlgq7",
+    });
+
+    expect(response.status).toEqual(204);
+    expect(deletedRoom).toEqual(null);
+  });
+
+  it("returns 400 status code if invalid roomId is provided", async () => {
+    const response = await request(appTest).delete(
+      `/api/rooms/invalid-room-id`,
+    );
+    expect(response.status).toBe(400);
   });
 });

--- a/tests/api/rooms.test.js
+++ b/tests/api/rooms.test.js
@@ -7,6 +7,45 @@ const Song = require("../../src/models/Song");
 const Note = require("../../src/models/Note");
 
 describe("GET /api/rooms", () => {
+  const mockRooms = [
+    {
+      song: "Fake Love",
+      createdBy: "최연석",
+      uid: "m5zw3tb2fqpfeqjmg97twmyhlgq2",
+    },
+    {
+      song: "왕벌의 비행",
+      createdBy: "복달",
+      uid: "G30XEWAkD9eJTSDdluAoISMcPVC2",
+    },
+    {
+      song: "Your Song",
+      createdBy: "송미르",
+      uid: "M5ZW3tB2FQPfeQJMG97TWmyHLGQ2",
+    },
+  ];
+
+  const mockSongs = [
+    {
+      title: "Fake Love",
+      audioURL: "https://bucketname.s3.location.amazonaws/music/fakelove",
+      imageURL: "https://bucketname.s3.location.amazonaws/image/fakelove",
+      artist: "BTS",
+    },
+    {
+      title: "왕벌의 비행",
+      audioURL: "https://bucketname.s3.location.amazonaws/music/memory",
+      imageURL: "https://bucketname.s3.location.amazonaws/image/memory",
+      artist: "Rimsky-Korsakov",
+    },
+    {
+      title: "Your Song",
+      audioURL: "https://bucketname.s3.location.amazonaws/music/yoursong",
+      imageURL: "https://bucketname.s3.location.amazonaws/image/yoursong",
+      artist: "Elton John",
+    },
+  ];
+
   beforeAll(async () => {
     await mongoMemoryServer.connect();
     await BattleRoom.deleteMany({});
@@ -17,64 +56,16 @@ describe("GET /api/rooms", () => {
   });
 
   beforeEach(async () => {
-    const songOne = {
-      title: "Fake Love",
-      audioURL: "https://bucketname.s3.location.amazonaws/music/fakelove",
-      imageURL: "https://bucketname.s3.location.amazonaws/image/fakelove",
-      artist: "BTS",
-    };
+    await Song.insertMany(mockSongs);
 
-    const songTwo = {
-      title: "왕벌의 비행",
-      audioURL: "https://bucketname.s3.location.amazonaws/music/memory",
-      imageURL: "https://bucketname.s3.location.amazonaws/image/memory",
-      artist: "Rimsky-Korsakov",
-    };
+    const addedSongs = await Song.find();
 
-    const songThree = {
-      title: "Your Song",
-      audioURL: "https://bucketname.s3.location.amazonaws/music/yoursong",
-      imageURL: "https://bucketname.s3.location.amazonaws/image/yoursong",
-      artist: "Elton John",
-    };
+    const battleRooms = mockRooms.map((data, index) => ({
+      ...data,
+      song: addedSongs[index]._id,
+    }));
 
-    await Song.create(songOne);
-    await Song.create(songTwo);
-    await Song.create(songThree);
-
-    const addedSongOne = await Song.findOne({
-      title: "Fake Love",
-    });
-
-    const addedSongTwo = await Song.findOne({
-      title: "왕벌의 비행",
-    });
-
-    const addedSongThree = await Song.findOne({
-      title: "Your Song",
-    });
-
-    const roomOne = {
-      song: addedSongOne._id,
-      createdBy: "최연석",
-      uid: "m5zw3tb2fqpfeqjmg97twmyhlgq2",
-    };
-
-    const roomTwo = {
-      song: addedSongTwo._id,
-      createdBy: "복달",
-      uid: "G30XEWAkD9eJTSDdluAoISMcPVC2",
-    };
-
-    const roomThree = {
-      song: addedSongThree._id,
-      createdBy: "송미르",
-      uid: "M5ZW3tB2FQPfeQJMG97TWmyHLGQ2",
-    };
-
-    await BattleRoom.create(roomOne);
-    await BattleRoom.create(roomTwo);
-    await BattleRoom.create(roomThree);
+    await BattleRoom.insertMany(battleRooms);
   });
 
   afterEach(async () => {
@@ -85,9 +76,11 @@ describe("GET /api/rooms", () => {
   it("returns all the existing battle rooms", async () => {
     const response = await request(app).get("/api/rooms");
     expect(response.status).toEqual(200);
-    expect(response.body.rooms).toHaveLength(3);
+    expect(response.body.rooms).toHaveLength(mockRooms.length);
 
-    const expectedRooms = await BattleRoom.find({});
+    const expectedRooms = await BattleRoom.find();
+
+    expect(mockRooms.length).toEqual(expectedRooms.length);
 
     response.body.rooms.forEach((room, index) => {
       expect(room.createdBy).toEqual(expectedRooms[index].createdBy);
@@ -126,40 +119,35 @@ describe("GET /api/rooms/new", () => {
   it("returns a list of songs with their corresponding audio and image URLs", async () => {
     const response = await request(appTest).get("/api/rooms/new");
 
-    expect(response.status).toBe(200);
+    expect(response.status).toEqual(200);
     expect(response.body.songs.length).toEqual(3);
+
     response.body.songs.forEach((song) => {
       expect(song).toHaveProperty("_id");
       expect(song).toHaveProperty("title");
-      expect(typeof song.title).toEqual("string");
-      expect(song.title.length).toBeGreaterThan(1);
       expect(song).toHaveProperty("audioURL");
       expect(song).toHaveProperty("imageURL");
       expect(song).toHaveProperty("artist");
+
+      expect(typeof song.title).toEqual("string");
       expect(typeof song.artist).toEqual("string");
+
+      expect(song.title.length).toBeGreaterThan(1);
       expect(song.artist.length).toBeGreaterThan(1);
     });
   });
 });
 
 describe("POST /api/rooms/new", () => {
-  let addedSong;
+  const mockSong = {
+    title: "Billie Jean",
+    audioURL: "https://bucketname.s3.location.amazonaws/music/billiejean",
+    imageURL: "https://bucketname.s3.location.amazonaws/image/billiejean",
+    artist: "Micheal Jackson",
+  };
 
   beforeAll(async () => {
     await mongoMemoryServer.connect();
-
-    const testSong = {
-      title: "Billie Jean",
-      audioURL: "https://bucketname.s3.location.amazonaws/music/billiejean",
-      imageURL: "https://bucketname.s3.location.amazonaws/image/billiejean",
-      artist: "Micheal Jackson",
-    };
-
-    await Song.create(testSong);
-
-    addedSong = await Song.findOne({
-      title: "Billie Jean",
-    });
   });
 
   afterAll(async () => {
@@ -171,7 +159,13 @@ describe("POST /api/rooms/new", () => {
   });
 
   it("creates a new battle room with valid request data and returns 201 status code", async () => {
-    const roomListBefore = await BattleRoom.find({});
+    const roomListBefore = await BattleRoom.find();
+
+    await Song.create(mockSong);
+
+    const addedSong = await Song.findOne({
+      title: "Billie Jean",
+    });
 
     const newRoom = {
       song: addedSong._id,
@@ -183,7 +177,7 @@ describe("POST /api/rooms/new", () => {
       .post("/api/rooms/new")
       .send(newRoom);
 
-    const roomListAfter = await BattleRoom.find({});
+    const roomListAfter = await BattleRoom.find();
 
     const addedRoom = await BattleRoom.find({
       uid: newRoom.uid,
@@ -195,6 +189,12 @@ describe("POST /api/rooms/new", () => {
   });
 
   it("returns a 400 status when the request body is missing a field", async () => {
+    await Song.create(mockSong);
+
+    const addedSong = await Song.findOne({
+      title: "Billie Jean",
+    });
+
     const newRoom = {
       song: addedSong._id,
       createdBy: "artist",
@@ -210,16 +210,40 @@ describe("POST /api/rooms/new", () => {
 });
 
 describe("GET /api/rooms/:roomId", () => {
-  let idFound;
+  const mockUser = {
+    uid: "652df1ac5bfa32a524169098",
+    password: "testpassword",
+    name: "Test User",
+    photoURL: "http://example/com/test.jpg",
+  };
+
+  const newNote = {
+    title: "Billie Jean",
+    note: [
+      {
+        time: 0.2,
+        key: "s",
+        positionY: 0,
+      },
+      {
+        time: 0.3,
+        key: "d",
+        positionY: 0,
+      },
+    ],
+  };
+
+  const sampleSong = {
+    title: newNote.title,
+    audioURL: "https://bucketname.s3.location.amazonaws/music/billiejean",
+    imageURL: "https://bucketname.s3.location.amazonaws/image/billiejean",
+    artist: "Micheal Jackson",
+  };
 
   beforeAll(async () => {
     await mongoMemoryServer.connect();
-    const sampleSong = {
-      title: "Billie Jean",
-      audioURL: "https://bucketname.s3.location.amazonaws/music/billiejean",
-      imageURL: "https://bucketname.s3.location.amazonaws/image/billiejean",
-      artist: "Micheal Jackson",
-    };
+
+    await Note.create(newNote);
 
     await Song.create(sampleSong);
 
@@ -227,37 +251,13 @@ describe("GET /api/rooms/:roomId", () => {
       title: sampleSong.title,
     });
 
-    const newNote = {
-      title: sampleSong.title,
-      note: [
-        {
-          time: 0.2,
-          key: "s",
-          positionY: 0,
-        },
-        {
-          time: 0.3,
-          key: "d",
-          positionY: 0,
-        },
-      ],
-    };
-
-    await Note.create(newNote);
-
     const newRoom = {
       song: addedSong._id,
-      createdBy: "artist",
-      uid: "m5zw3tb2fqpfeqjmg97twmyhlgq3",
+      createdBy: mockUser.name,
+      uid: mockUser.uid,
     };
 
     await BattleRoom.create(newRoom);
-
-    const roomIdFound = await BattleRoom.findOne({
-      uid: "m5zw3tb2fqpfeqjmg97twmyhlgq3",
-    });
-
-    idFound = roomIdFound._id.toString();
   });
 
   afterAll(async () => {
@@ -275,6 +275,11 @@ describe("GET /api/rooms/:roomId", () => {
   });
 
   it("returns a room, song, and note when given a valid roomId", async () => {
+    const roomId = await BattleRoom.findOne({
+      uid: mockUser.uid,
+    });
+
+    const idFound = roomId._id;
     const response = await request(appTest).get(`/api/rooms/${idFound}`);
 
     expect(response.status).toEqual(200);
@@ -285,6 +290,13 @@ describe("GET /api/rooms/:roomId", () => {
 });
 
 describe("DELETE /api/rooms/:roomId", () => {
+  const mockUser = {
+    uid: "652df1ac5bfa32a524169098",
+    password: "testpassword",
+    name: "Test User",
+    photoURL: "http://example/com/test.jpg",
+  };
+
   beforeAll(async () => {
     await mongoMemoryServer.connect();
 
@@ -304,7 +316,7 @@ describe("DELETE /api/rooms/:roomId", () => {
     const testRoom = {
       song: addedSongOne._id,
       createdBy: "도레미",
-      uid: "m5zw3tb2fqpfeqjmg97twmyhlgq7",
+      uid: mockUser.uid,
     };
 
     await BattleRoom.create(testRoom);
@@ -316,14 +328,14 @@ describe("DELETE /api/rooms/:roomId", () => {
 
   it("deletes a battle room and return 204 status code", async () => {
     const roomIdFound = await BattleRoom.findOne({
-      uid: "m5zw3tb2fqpfeqjmg97twmyhlgq7",
+      uid: mockUser.uid,
     });
 
-    const idFound = roomIdFound._id.toString();
+    const idFound = roomIdFound._id;
 
     const response = await request(appTest).delete(`/api/rooms/${idFound}`);
     const deletedRoom = await BattleRoom.findOne({
-      uid: "m5zw3tb2fqpfeqjmg97twmyhlgq7",
+      uid: idFound,
     });
 
     expect(response.status).toEqual(204);
@@ -334,6 +346,7 @@ describe("DELETE /api/rooms/:roomId", () => {
     const response = await request(appTest).delete(
       `/api/rooms/invalid-room-id`,
     );
-    expect(response.status).toBe(400);
+
+    expect(response.status).toEqual(400);
   });
 });

--- a/tests/api/users.test.js
+++ b/tests/api/users.test.js
@@ -2,6 +2,7 @@ const request = require("supertest");
 const app = require("../../src/app");
 const User = require("../../src/models/User");
 const mongoMemoryServer = require("../../mongoMemoryServer");
+const bcrypt = require("bcrypt");
 
 describe("POST /api/users/login", () => {
   beforeAll(async () => {
@@ -28,7 +29,7 @@ describe("POST /api/users/login", () => {
   });
 
   it("returns a 201 response with all users and a token if the user does not exist", async () => {
-    const mockUser = {
+    const newMockUser = {
       accessToken: "access-token",
       uid: "641df1ac5bfa32a524169098",
       name: "Charlie Brown",
@@ -40,10 +41,10 @@ describe("POST /api/users/login", () => {
     const response = await request(app)
       .post("/api/users/login")
       .send({
-        accessToken: mockUser.accessToken,
-        uid: mockUser.uid,
-        displayName: mockUser.name,
-        photoURL: mockUser.photoURL,
+        accessToken: newMockUser.accessToken,
+        uid: newMockUser.uid,
+        displayName: newMockUser.name,
+        photoURL: newMockUser.photoURL,
       })
       .set("Content-Type", "application/json")
       .set("Accept", "application/json");
@@ -54,27 +55,171 @@ describe("POST /api/users/login", () => {
 
     const usersAfter = await User.find({});
     const addedUser = await User.findOne({
-      uid: mockUser.uid,
+      uid: newMockUser.uid,
     });
 
     expect(usersAfter.length).toEqual(usersBefore.length + 1);
     expect(addedUser).toBeDefined();
   });
 
-  it("return a 401 response with an error message if any of user data is missing", async () => {
-    const mockUser = {
+  it("returns a 401 response with an error message if any of user data is missing", async () => {
+    const invalidMockUser = {
       uid: "641df1ac5bfa32a524169098",
       name: "Charlie Brown",
       photoURL: "https://www.peanuts.com/sites/default/files/cb-color.jpg",
     };
 
     const response = await request(app).post("/api/users/login").send({
-      uid: mockUser.uid,
-      displayName: mockUser.name,
-      photoURL: mockUser.photoURL,
+      uid: invalidMockUser.uid,
+      displayName: invalidMockUser.name,
+      photoURL: invalidMockUser.photoURL,
     });
 
     expect(response.status).toEqual(401);
     expect(response.body).toEqual({ message: "Invalid user" });
+  });
+});
+
+describe("POST /api/users/logout", () => {
+  it("logs out the user and returns a 204 response", async () => {
+    const response = await request(app).post("/api/users/logout");
+
+    expect(response.status).toBe(204);
+    expect(response.headers["set-cookie"][0]).toContain("jwt=;");
+  });
+});
+
+describe("POST api/users/local/register", () => {
+  let mockUser;
+
+  beforeAll(async () => {
+    await mongoMemoryServer.connect();
+    mockUser = {
+      uid: "652df1ac5bfa32a524169098",
+      password: "testpassword",
+      displayName: "Test User",
+      photoURL: "http://example/com/test.jpg",
+    };
+  });
+
+  afterAll(async () => {
+    await User.deleteMany({});
+    await mongoMemoryServer.closeDatabase();
+  });
+
+  it("returns 201 on successful registration", async () => {
+    const response = await request(app).post("/api/users/local/register").send({
+      uid: mockUser.uid,
+      password: mockUser.password,
+      displayName: mockUser.displayName,
+      photoURL: mockUser.photoURL,
+    });
+
+    const userFound = await User.find({ uid: "652df1ac5bfa32a524169098" });
+
+    expect(response.status).toEqual(201);
+    expect(response.body.result).toEqual("Success");
+    expect(userFound[0]).toBeDefined();
+    expect(userFound[0].uid).toEqual(mockUser.uid);
+    expect(userFound[0].name).toEqual(mockUser.displayName);
+    expect(userFound[0].photoURL).toEqual(mockUser.photoURL);
+  });
+});
+
+describe("POST /api/users/local/login", () => {
+  beforeAll(async () => {
+    await mongoMemoryServer.connect();
+
+    mockUser = {
+      uid: "652df1ac5bfa32a524169098",
+      password: "testpassword",
+      displayName: "Test User",
+      photoURL: "http://example/com/test.jpg",
+    };
+
+    const password = await bcrypt.hash(mockUser.password, 10);
+
+    await User.create({
+      uid: mockUser.uid,
+      password: password,
+      name: mockUser.displayName,
+      photoURL: mockUser.photoURL,
+    });
+  });
+
+  afterAll(async () => {
+    await mongoMemoryServer.closeDatabase();
+  });
+
+  afterEach(async () => {
+    await User.deleteMany({});
+  });
+
+  it("should return 201 and user info on successful login", async () => {
+    const response = await request(app).post("/api/users/local/login").send({
+      uid: mockUser.uid,
+      password: mockUser.password,
+    });
+
+    const userFound = await User.find({ uid: mockUser.uid });
+
+    expect(response.status).toBe(201);
+    expect(response.body.user.uid).toEqual(mockUser.uid);
+    expect(response.body.user.name).toEqual(mockUser.displayName);
+    expect(userFound).toBeDefined();
+  });
+
+  it("should return 400 on unsuccessful login", async () => {
+    const password = await bcrypt.hash(mockUser.password, 10);
+
+    await User.create({
+      uid: mockUser.uid,
+      password: password,
+      name: mockUser.displayName,
+      photoURL: mockUser.photoURL,
+    });
+
+    const response = await request(app).post("/api/users/local/login").send({
+      password: "wrongpassword",
+      uid: mockUser.uid,
+    });
+
+    expect(response.status).toBe(400);
+    expect(response.body.message).toEqual(
+      "No user with that email or password",
+    );
+  });
+});
+
+describe("DELETE /api/users/delete", () => {
+  let mockUser;
+  beforeAll(async () => {
+    await mongoMemoryServer.connect();
+    mockUser = {
+      uid: "652df1ac5bfa32a524169098",
+      password: "testpassword",
+      name: "Test User",
+      photoURL: "http://example/com/test.jpg",
+    };
+
+    await User.create(mockUser);
+  });
+
+  afterAll(async () => {
+    await mongoMemoryServer.closeDatabase();
+  });
+
+  it("deletes the user and return 204 code", async () => {
+    const userBefore = await User.findOne({ uid: mockUser.uid });
+
+    const response = await request(app).delete("/api/users/delete").send({
+      email: mockUser.uid,
+    });
+
+    const userAfter = await User.findOne({ uid: mockUser.uid });
+
+    expect(response.status).toEqual(204);
+    expect(userBefore).toBeDefined();
+    expect(userAfter).toEqual(null);
   });
 });

--- a/tests/middlewares/verifyToken.test.js
+++ b/tests/middlewares/verifyToken.test.js
@@ -1,0 +1,38 @@
+const request = require("supertest");
+const jwt = require("jsonwebtoken");
+const app = require("../../src/app");
+const verifyToken = require("../../src/routes/middlewares/verifyToken");
+
+describe("verifyToken middleware", () => {
+  it("returns 403 status code when no token is provided", async () => {
+    const response = await request(app)
+      .get("/api/rooms/new")
+      .set("authorization", "Bearer ");
+    expect(response.status).toEqual(403);
+    expect(response.body.message).toEqual("Unauthorized user");
+  });
+
+  it("passes through to next middleware when token is valid", () => {
+    const req = {
+      headers: {
+        authorization: "Bearer validtoken",
+      },
+    };
+
+    const res = {
+      send: jest.fn(),
+    };
+
+    const next = jest.fn();
+
+    jest
+      .spyOn(jwt, "verify")
+      .mockReturnValueOnce({ uid: "652df1ac5bfa32a524169098" });
+
+    verifyToken(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+
+    expect(res.send).not.toHaveBeenCalled();
+  });
+});

--- a/tests/middlewares/verifyToken.test.js
+++ b/tests/middlewares/verifyToken.test.js
@@ -1,9 +1,23 @@
 const request = require("supertest");
 const jwt = require("jsonwebtoken");
 const app = require("../../src/app");
+const User = require("../../src/models/User");
+const mongoMemoryServer = require("../../mongoMemoryServer");
 const verifyToken = require("../../src/routes/middlewares/verifyToken");
 
 describe("verifyToken middleware", () => {
+  beforeAll(async () => {
+    await mongoMemoryServer.connect();
+  });
+
+  afterAll(async () => {
+    await mongoMemoryServer.closeDatabase();
+  });
+
+  afterEach(async () => {
+    await User.deleteMany({});
+  });
+
   it("returns 403 status code when no token is provided", async () => {
     const response = await request(app)
       .get("/api/rooms/new")
@@ -12,10 +26,28 @@ describe("verifyToken middleware", () => {
     expect(response.body.message).toEqual("Unauthorized user");
   });
 
-  it("passes through to next middleware when token is valid", () => {
+  it("passes through to next middleware when token is valid", async () => {
+    const mockUser = {
+      uid: "641df1ac5bfa32a524169090",
+      name: "Charlie Black",
+      photoURL: "https://www.pbb/cb-color.jpg",
+    };
+
+    await User.create(mockUser);
+
+    const loginResponse = await request(app)
+      .post("/api/users/local/login")
+      .send({
+        uid: mockUser.uid,
+        name: mockUser.name,
+        photoURL: mockUser.photoURL,
+      });
+
+    const token = loginResponse.body.token;
+
     const req = {
       headers: {
-        authorization: "Bearer validtoken",
+        authorization: `Bearer ${token}`,
       },
     };
 
@@ -25,11 +57,9 @@ describe("verifyToken middleware", () => {
 
     const next = jest.fn();
 
-    jest
-      .spyOn(jwt, "verify")
-      .mockReturnValueOnce({ uid: "652df1ac5bfa32a524169098" });
+    jest.spyOn(jwt, "verify").mockReturnValueOnce(mockUser.uid);
 
-    verifyToken(req, res, next);
+    await verifyToken(req, res, next);
 
     expect(next).toHaveBeenCalled();
 

--- a/tests/mocks/auth.mock.js
+++ b/tests/mocks/auth.mock.js
@@ -1,0 +1,10 @@
+const mockedVerifyToken = (req, res, next) => {
+  req.user = {
+    id: "test-user-id",
+  };
+  next();
+};
+
+module.exports = {
+  mockedVerifyToken,
+};

--- a/tests/proxy/audio-server.test.js
+++ b/tests/proxy/audio-server.test.js
@@ -1,0 +1,23 @@
+const request = require("supertest");
+const app = require("../../src/app");
+
+describe("GET /proxy/audio-server", () => {
+  it("returns audio data as buffer", async () => {
+    const audioURL = `https://${process.env.AWS_BUCKET}.s3.${process.env.AWS_REGION}.amazonaws.com/music/Samurai-Techno-by-fizzd/music.mp3`;
+
+    const response = await request(app).get(
+      `/proxy/audio-server?url=${audioURL}`,
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toBe("audio/mpeg");
+    expect(response.body).toBeInstanceOf(Buffer);
+  });
+
+  it("returns 400 error if missing audio URL", async () => {
+    const response = await request(app).get("/proxy/audio-server?url=");
+
+    expect(response.status).toBe(400);
+    expect(response.text).toBe("Missing audio URL");
+  });
+});


### PR DESCRIPTION
## 📝 Description

서버 유닛테스트로 /api/users, /api/rooms, /proxy/audio-server 관련 endpoint와  verifyToken 미들웨어를 테스트하였습니다.

## ❗ Related Issues
app.test.js를 tests로 이동시키려 했으나 이동 후 app.test.js를 테스트할 suite로 인식하여 다른 위치를 생각 중입니다.
 
## 🛠️ Changes

users.test.js에 로컬 로그인 관련 endpoint에 대한 테스트를 추가하였습니다.
- POST /api/users/logout
- POST api/users/local/register
- POST api/users/local/login
- DELETE api/users/delete

rooms.test.js에 배틀룸 관련 endpoint에 대한 테스트를 추가하셨습니다.
- GET /api/rooms/new
- POST /api/rooms/new
- GET /api/rooms/:roomId
- DELETE /api/rooms/:roomId

audio-server.test.js에 오디오프록시 관련 테스트를 추가하였습니다.
- GET /proxy/audio-server

verifyToken.test.js에 verifyToken 관련테스트를 추가하였습니다.

rooms.test.js에 테스트를 위해 verifyToken 미들웨어를 모킹하여 mockedVerifyToken을 만들었습니다. 테스트 전용 app.test.js를 만들고 mockedVerifyToken을 실행하는 경로는 테스트에서 request(appTest)로 테스트 전용 app에 요청을 보냈습니다.

## 📸 Screenshot

<img width="400" alt="Screen Shot 2023-03-29 at 2 20 49 PM" src="https://user-images.githubusercontent.com/115068443/228442297-fb9796e8-f946-4712-af7c-654a9f415505.png">
