### PR TITLE
feat: POST api/records/new

### DIFF
--- a/src/models/Record.js
+++ b/src/models/Record.js
@@ -1,0 +1,29 @@
+const mongoose = require("mongoose");
+
+const RecordSchema = new mongoose.Schema({
+  uid: {
+    type: String,
+    required: true,
+    trim: true,
+  },
+  name: {
+    type: String,
+    required: true,
+    trim: true,
+    minlength: 2,
+    maxlength: 20,
+  },
+  photoURL: {
+    type: String,
+    trim: true,
+  },
+  title: {
+    type: String,
+    required: true,
+  },
+  totalScore: {
+    type: Number,
+    required: true,
+  },
+});
+module.exports = mongoose.model("Record", RecordSchema);

--- a/src/routes/controllers/record.Controller.js
+++ b/src/routes/controllers/record.Controller.js
@@ -1,0 +1,33 @@
+const Record = require("../../models/Record");
+const BattleRoom = require("../../models/BattleRoom");
+const Song = require("../../models/Song");
+
+exports.saveRecord = async (req, res, next) => {
+  const { uid, displayName, photoURL, totalScore, resultId } = req.body;
+
+  console.log(uid, displayName, photoURL, totalScore, resultId);
+
+  if (!uid || !displayName || !totalScore || !resultId) {
+    return res.status(400).send({ message: "Invalid requested body" });
+  }
+
+  try {
+    console.log(uid, displayName, photoURL, totalScore, resultId);
+
+    const room = await BattleRoom.findOne({ _id: resultId });
+
+    const song = await Song.findOne({ _id: room.song });
+
+    const record = await Record.create({
+      uid,
+      name: displayName,
+      photoURL,
+      title: song.title,
+      totalScore,
+    });
+
+    res.status(201).send({ record });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -3,8 +3,10 @@ const router = express.Router();
 
 const users = require("./users");
 const rooms = require("./rooms");
+const records = require("./records");
 
 router.use("/users", users);
 router.use("/rooms", rooms);
+router.use("/records", records);
 
 module.exports = router;

--- a/src/routes/records.js
+++ b/src/routes/records.js
@@ -1,0 +1,9 @@
+const express = require("express");
+const router = express.Router();
+const recordController = require("./controllers/record.Controller");
+const verifyToken = require("./middlewares/verifyToken");
+
+// router.get("/", verifyToken);
+router.post("/new", verifyToken, recordController.saveRecord);
+
+module.exports = router;


### PR DESCRIPTION
## 📝 Description
- 점수 저장 기능을 위해 `POST: api/records/new` 라우터를 추가해 주었습니다.
- `uid`, `name`, `photoURL`, `title`, `totalScore` 를 `db`에 저장 합니다.
- `Record` 스키마를 추가해 주었습니다.

## ❗ Related Issues
N/A

## 🛠️ Changes
N/A

## 📸 Screenshot
N/A